### PR TITLE
Add customizable log levels

### DIFF
--- a/MultiplayerMod/Core/Loader/ModLoader.cs
+++ b/MultiplayerMod/Core/Loader/ModLoader.cs
@@ -4,12 +4,13 @@ using System.Reflection;
 using HarmonyLib;
 using KMod;
 using MultiplayerMod.Core.Extensions;
+using MultiplayerMod.Core.Logging;
 
 namespace MultiplayerMod.Core.Loader;
 
 public class ModLoader : UserMod2 {
 
-    private readonly Logging.Logger log = new(typeof(ModLoader));
+    private readonly Logging.Logger log = LoggerFactory.GetLogger<ModLoader>();
 
     public override void OnLoad(Harmony harmony) {
         base.OnLoad(harmony);

--- a/MultiplayerMod/Core/Logging/LogLevel.cs
+++ b/MultiplayerMod/Core/Logging/LogLevel.cs
@@ -1,7 +1,6 @@
 ﻿namespace MultiplayerMod.Core.Logging;
 
-public enum LogLevel
-{
+public enum LogLevel {
     Trace,
     Debug,
     Info,

--- a/MultiplayerMod/Core/Logging/Logger.cs
+++ b/MultiplayerMod/Core/Logging/Logger.cs
@@ -11,22 +11,38 @@ public class Logger {
 
     public Logger(Type type) {
         group = type.Name;
+
+        var level = Environment.GetEnvironmentVariable("MULTIPLAYERMOD.LOGGING.LEVEL");
+        if (level != null && Enum.TryParse<LogLevel>(level, true, out var globalLevel))
+            Level = globalLevel;
+        level = Environment.GetEnvironmentVariable($"MULTIPLAYERMOD.LOGGING.{type.Name.ToUpper()}");
+        if (level != null && Enum.TryParse<LogLevel>(level, true, out var specificLevel))
+            Level = specificLevel;
     }
 
-    public void Info(string message) => Log(LogLevel.Info, message);
-    public void Warning(string message) => Log(LogLevel.Warning, message);
-    public void Error(string message) => Log(LogLevel.Error, message);
-    public void Debug(string message) => Log(LogLevel.Debug, message);
-    public void Trace(string message) => Log(LogLevel.Trace, message);
-    public void Trace(Func<string> messageProvider) => Log(LogLevel.Trace, messageProvider());
+    public void Info(string message) => Log(LogLevel.Info, () => message);
+    public void Info(Func<string> message) => Log(LogLevel.Info, message);
 
-    private void Log(LogLevel level, string message) {
+    public void Warning(string message) => Log(LogLevel.Warning, () => message);
+    public void Warning(Func<string> message) => Log(LogLevel.Warning, message);
+
+    public void Error(string message) => Log(LogLevel.Error, () => message);
+    public void Error(Func<string> message) => Log(LogLevel.Error, message);
+
+    public void Debug(string message) => Log(LogLevel.Debug, () => message);
+    public void Debug(Func<string> message) => Log(LogLevel.Debug, message);
+
+    public void Trace(string message) => Log(LogLevel.Trace, () => message);
+    public void Trace(Func<string> message) => Log(LogLevel.Trace, message);
+
+    private void Log(LogLevel level, Func<string> message) {
         if (level < Level)
             return;
+
         var timestamp = System.DateTime.UtcNow.ToString("HH:mm:ss.fff");
         var threadId = Thread.CurrentThread.ManagedThreadId;
         var levelId = level.ToString().ToUpper();
-        Console.WriteLine($"[{timestamp}] [{threadId}] [{levelId}] [{group}] {message}");
+        Console.WriteLine($"[{timestamp}] [{threadId}] [{levelId}] [{group}] {message()}");
     }
 
 }

--- a/MultiplayerMod/Core/Logging/LoggerFactory.cs
+++ b/MultiplayerMod/Core/Logging/LoggerFactory.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using MultiplayerMod.Core.Extensions;
+
+namespace MultiplayerMod.Core.Logging;
+
+public static class LoggerFactory {
+
+    private static readonly Dictionary<string, LogLevel> levels = new();
+    private static readonly Regex Pattern = new Regex("(.*?)=(.*)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    static LoggerFactory() {
+        Environment.GetCommandLineArgs().ForEach(ParseLogConfiguration);
+    }
+
+    private static void ParseLogConfiguration(string arg) {
+        var match = Pattern.Match(arg);
+        if (!match.Success)
+            return;
+
+        var id = match.Groups[1].Value.ToLower();
+        if (!id.StartsWith("log."))
+            return;
+
+        var levelName = match.Groups[2].Value;
+        if (!Enum.TryParse<LogLevel>(levelName, true, out var level))
+            return;
+
+        var type = id.Substring(4);
+        levels[type] = level;
+    }
+
+    public static Logger GetLogger<T>() => GetLogger(typeof(T));
+
+    public static Logger GetLogger(Type type) {
+        var logger = new Logger(type);
+        if (levels.TryGetValue(type.Name.ToLower(), out var level))
+            logger.Level = level;
+        else if (levels.TryGetValue("level", out var global))
+            logger.Level = global;
+        return logger;
+    }
+
+}

--- a/MultiplayerMod/Core/Scheduling/UnityTaskSchedulerLoader.cs
+++ b/MultiplayerMod/Core/Scheduling/UnityTaskSchedulerLoader.cs
@@ -1,13 +1,14 @@
 ﻿using HarmonyLib;
 using MultiplayerMod.Core.Dependency;
 using MultiplayerMod.Core.Loader;
+using MultiplayerMod.Core.Logging;
 using MultiplayerMod.Core.Unity;
 
 namespace MultiplayerMod.Core.Scheduling;
 
 public class UnityTaskSchedulerLoader : IModComponentLoader {
 
-    private readonly Logging.Logger log = new(typeof(UnityTaskSchedulerLoader));
+    private readonly Logging.Logger log = LoggerFactory.GetLogger<UnityTaskSchedulerLoader>();
 
     public void OnLoad(Harmony harmony) {
         log.Debug("Creating task scheduler...");

--- a/MultiplayerMod/Multiplayer/Commands/Chores/FindNextChore.cs
+++ b/MultiplayerMod/Multiplayer/Commands/Chores/FindNextChore.cs
@@ -13,7 +13,7 @@ namespace MultiplayerMod.Multiplayer.Commands.Chores;
 [Serializable]
 public class FindNextChore : IMultiplayerCommand {
 
-    private static Core.Logging.Logger log = new(typeof(FindNextChore));
+    private static Core.Logging.Logger log = LoggerFactory.GetLogger<FindNextChore>();
 
     private string instanceType;
     private int instanceId;

--- a/MultiplayerMod/Multiplayer/Configuration/GameEventBindings.cs
+++ b/MultiplayerMod/Multiplayer/Configuration/GameEventBindings.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using MultiplayerMod.Core.Dependency;
+using MultiplayerMod.Core.Logging;
 using MultiplayerMod.Game;
 using MultiplayerMod.Multiplayer.Commands.GameTools;
 using MultiplayerMod.Multiplayer.Commands.Speed;
@@ -12,7 +13,7 @@ namespace MultiplayerMod.Multiplayer.Configuration;
 
 public class GameEventBindings {
 
-    private readonly Core.Logging.Logger log = new(typeof(GameEventBindings));
+    private readonly Core.Logging.Logger log = LoggerFactory.GetLogger<GameEventBindings>();
 
     private readonly IMultiplayerClient client = Container.Get<IMultiplayerClient>();
 

--- a/MultiplayerMod/Multiplayer/Configuration/MultiplayerCoordinator.cs
+++ b/MultiplayerMod/Multiplayer/Configuration/MultiplayerCoordinator.cs
@@ -1,4 +1,5 @@
 ﻿using MultiplayerMod.Core.Dependency;
+using MultiplayerMod.Core.Logging;
 using MultiplayerMod.Core.Patch;
 using MultiplayerMod.Core.Unity;
 using MultiplayerMod.Game;
@@ -14,7 +15,7 @@ namespace MultiplayerMod.Multiplayer.Configuration;
 
 public class MultiplayerCoordinator {
 
-    private readonly Core.Logging.Logger log = new(typeof(MultiplayerCoordinator));
+    private readonly Core.Logging.Logger log = LoggerFactory.GetLogger<MultiplayerCoordinator>();
 
     private readonly IMultiplayerServer server = Container.Get<IMultiplayerServer>();
     private readonly IMultiplayerClient client = Container.Get<IMultiplayerClient>();

--- a/MultiplayerMod/Multiplayer/Configuration/ServerEventBindings.cs
+++ b/MultiplayerMod/Multiplayer/Configuration/ServerEventBindings.cs
@@ -1,4 +1,5 @@
 ﻿using MultiplayerMod.Core.Dependency;
+using MultiplayerMod.Core.Logging;
 using MultiplayerMod.Game;
 using MultiplayerMod.Game.Chores;
 using MultiplayerMod.Multiplayer.Commands.Chores;
@@ -13,7 +14,7 @@ namespace MultiplayerMod.Multiplayer.Configuration;
 
 public class ServerEventBindings {
 
-    private readonly Core.Logging.Logger log = new(typeof(ServerEventBindings));
+    private readonly Core.Logging.Logger log = LoggerFactory.GetLogger<ServerEventBindings>();
     private readonly IMultiplayerServer server = Container.Get<IMultiplayerServer>();
     private bool bound;
 

--- a/MultiplayerMod/Multiplayer/Debug/WorldDebugSnapshot.cs
+++ b/MultiplayerMod/Multiplayer/Debug/WorldDebugSnapshot.cs
@@ -8,7 +8,8 @@ namespace MultiplayerMod.Multiplayer.Debug;
 
 [Serializable]
 public class WorldDebugSnapshot {
-    private static Core.Logging.Logger log = new(typeof(WorldDebugSnapshot));
+    private static Core.Logging.Logger log = LoggerFactory.GetLogger<WorldDebugSnapshot>();
+
     public float worldTime;
     public int cellsCount;
     public int[] elementIdxHashes;

--- a/MultiplayerMod/Multiplayer/State/MultiplayerState.cs
+++ b/MultiplayerMod/Multiplayer/State/MultiplayerState.cs
@@ -1,8 +1,10 @@
-﻿namespace MultiplayerMod.Multiplayer.State;
+﻿using MultiplayerMod.Core.Logging;
+
+namespace MultiplayerMod.Multiplayer.State;
 
 public static class MultiplayerState {
 
-    private static readonly Core.Logging.Logger log = new(typeof(MultiplayerState));
+    private static readonly Core.Logging.Logger log = LoggerFactory.GetLogger(typeof(MultiplayerState));
 
     private static MultiplayerRole role = MultiplayerRole.None;
 

--- a/MultiplayerMod/Platform/Steam/Network/Components/LobbyJoinRequestComponent.cs
+++ b/MultiplayerMod/Platform/Steam/Network/Components/LobbyJoinRequestComponent.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using MultiplayerMod.Core.Dependency;
+using MultiplayerMod.Core.Logging;
 using MultiplayerMod.Network;
 using Steamworks;
 using UnityEngine;
@@ -8,7 +9,7 @@ namespace MultiplayerMod.Platform.Steam.Network.Components;
 
 public class LobbyJoinRequestComponent : MonoBehaviour {
 
-    private readonly Core.Logging.Logger log = new(typeof(LobbyJoinRequestComponent));
+    private readonly Core.Logging.Logger log = LoggerFactory.GetLogger<LobbyJoinRequestComponent>();
 
     private SteamClient client;
     private Callback<GameLobbyJoinRequested_t> lobbyJoinRequestedCallback;

--- a/MultiplayerMod/Platform/Steam/Network/Messaging/NetworkMessageProcessor.cs
+++ b/MultiplayerMod/Platform/Steam/Network/Messaging/NetworkMessageProcessor.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
+using MultiplayerMod.Core.Logging;
 using Steamworks;
 using static MultiplayerMod.Platform.Steam.Network.Configuration;
 
@@ -10,7 +11,7 @@ namespace MultiplayerMod.Platform.Steam.Network.Messaging;
 public class NetworkMessageProcessor {
 
     private readonly ConcurrentDictionary<uint, ConcurrentDictionary<int, FragmentsBuffer>> fragments = new();
-    private readonly Core.Logging.Logger log = new(typeof(NetworkMessageProcessor));
+    private readonly Core.Logging.Logger log = LoggerFactory.GetLogger<NetworkMessageProcessor>();
 
     public NetworkMessage Process(uint clientId, INetworkMessageHandle handle) =>
         NetworkSerializer.Deserialize(handle) switch {

--- a/MultiplayerMod/Platform/Steam/Network/SteamClient.cs
+++ b/MultiplayerMod/Platform/Steam/Network/SteamClient.cs
@@ -2,6 +2,7 @@
 using System.Runtime.InteropServices;
 using MultiplayerMod.Core.Dependency;
 using MultiplayerMod.Core.Extensions;
+using MultiplayerMod.Core.Logging;
 using MultiplayerMod.Core.Unity;
 using MultiplayerMod.Multiplayer;
 using MultiplayerMod.Network;
@@ -22,7 +23,7 @@ public class SteamClient : IMultiplayerClient {
     public event EventHandler<ClientStateChangedEventArgs> StateChanged;
     public event EventHandler<CommandReceivedEventArgs> CommandReceived;
 
-    private readonly Core.Logging.Logger log = new(typeof(SteamClient));
+    private readonly Core.Logging.Logger log = LoggerFactory.GetLogger<SteamClient>();
     private readonly SteamLobby lobby = Container.Get<SteamLobby>();
     private readonly Lazy<IPlayer> playerContainer = new(() => new SteamPlayer(SteamUser.GetSteamID()));
 

--- a/MultiplayerMod/Platform/Steam/Network/SteamLobby.cs
+++ b/MultiplayerMod/Platform/Steam/Network/SteamLobby.cs
@@ -1,4 +1,4 @@
-﻿using MultiplayerMod.Network;
+﻿using MultiplayerMod.Core.Logging;
 using Steamworks;
 
 namespace MultiplayerMod.Platform.Steam.Network;
@@ -26,7 +26,7 @@ public class SteamLobby {
     public event LobbyEventHandler OnLeave;
     public event LobbyEventHandler OnJoin;
 
-    private readonly Core.Logging.Logger log = new(typeof(SteamLobby));
+    private readonly Core.Logging.Logger log = LoggerFactory.GetLogger<SteamLobby>();
     private readonly CallResult<LobbyCreated_t> lobbyCreatedCallback;
     private readonly CallResult<LobbyEnter_t> lobbyEnteredCallback;
 

--- a/MultiplayerMod/Platform/Steam/Network/SteamServer.cs
+++ b/MultiplayerMod/Platform/Steam/Network/SteamServer.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using MultiplayerMod.Core.Collections;
 using MultiplayerMod.Core.Dependency;
 using MultiplayerMod.Core.Extensions;
+using MultiplayerMod.Core.Logging;
 using MultiplayerMod.Core.Scheduling;
 using MultiplayerMod.Core.Unity;
 using MultiplayerMod.Multiplayer;
@@ -42,7 +43,7 @@ public class SteamServer : IMultiplayerServer {
     public event EventHandler<PlayerConnectedEventArgs> PlayerConnected;
     public event EventHandler<CommandReceivedEventArgs> CommandReceived;
 
-    private readonly Core.Logging.Logger log = new(typeof(SteamServer));
+    private readonly Core.Logging.Logger log = LoggerFactory.GetLogger<SteamServer>();
 
     private Callback<SteamServersConnected_t> steamServersConnectedCallback;
     private TaskCompletionSource<bool> lobbyCompletionSource;

--- a/MultiplayerMod/Platform/Steam/SteamPlatformLoader.cs
+++ b/MultiplayerMod/Platform/Steam/SteamPlatformLoader.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using MultiplayerMod.Core.Dependency;
 using MultiplayerMod.Core.Loader;
+using MultiplayerMod.Core.Logging;
 using MultiplayerMod.Core.Unity;
 using MultiplayerMod.Multiplayer;
 using MultiplayerMod.Network;
@@ -11,7 +12,7 @@ namespace MultiplayerMod.Platform.Steam;
 
 public class SteamPlatformLoader : IModComponentLoader {
 
-    private readonly Core.Logging.Logger log = new(typeof(SteamPlatformLoader));
+    private readonly Core.Logging.Logger log = LoggerFactory.GetLogger<SteamPlatformLoader>();
 
     public void OnLoad(Harmony harmony) {
         var steam = DistributionPlatform.Inst.Platform == "Steam";


### PR DESCRIPTION
To change the global log level use log.level=<level> as a command line argument. 
To change the specific logger log level use log.<logger name>=<level>. 
The levels are: trace, debug, info, warning, error.