### PR TITLE
#11 Fix missing IdleChore and MoveToSafetyChore.

### DIFF
--- a/MultiplayerMod/Game/Chores/ChoreConsumerEvents.cs
+++ b/MultiplayerMod/Game/Chores/ChoreConsumerEvents.cs
@@ -1,11 +1,14 @@
 using System;
 using HarmonyLib;
+using MultiplayerMod.Core.Logging;
 using MultiplayerMod.Multiplayer.State;
 
 namespace MultiplayerMod.Game.Chores;
 
 //[HarmonyPatch(typeof(ChoreConsumer), nameof(ChoreConsumer.FindNextChore))]
-public static class ChoreConsumerEvents {
+public class ChoreConsumerEvents {
+
+    private static readonly Core.Logging.Logger log = LoggerFactory.GetLogger<ChoreConsumerEvents>();
     public static event Action<FindNextChoreEventArgs> FindNextChore;
 
     public static void Postfix(ChoreConsumer __instance, Chore.Precondition.Context out_context, ref bool __result) {
@@ -19,14 +22,20 @@ public static class ChoreConsumerEvents {
         var instanceId = kPrefabID.InstanceID;
         var choreId = out_context.chore.id;
 
+        var args = new FindNextChoreEventArgs {
+            InstanceId = instanceId,
+            InstanceString = __instance.ToString(),
+            InstanceCell = Grid.PosToCell(__instance.transform.position),
+            ChoreId = choreId,
+            ChoreType = out_context.chore.GetType(),
+            ChoreCell = Grid.PosToCell(out_context.chore.gameObject.transform.position),
+            IsAttemptingOverride = out_context.isAttemptingOverride
+        };
+        log.Debug(
+            $"Triggering {args.InstanceId} {args.InstanceString} {args.InstanceCell} {args.ChoreId} {args.ChoreType} {args.ChoreCell}"
+        );
         FindNextChore?.Invoke(
-            new FindNextChoreEventArgs {
-                InstanceId = instanceId,
-                InstanceType = __instance.GetType(),
-                ChoreId = choreId,
-                ChoreType = out_context.chore.GetType(),
-                ChoreCell = Grid.PosToCell(out_context.chore.gameObject.transform.position)
-            }
+            args
         );
     }
 
@@ -35,8 +44,11 @@ public static class ChoreConsumerEvents {
 public class FindNextChoreEventArgs : EventArgs {
     public int InstanceId { get; init; }
 
-    public Type InstanceType { get; init; }
+    public string InstanceString { get; init; }
+
+    public int InstanceCell { get; init; }
     public int ChoreId { get; init; }
     public Type ChoreType { get; init; }
     public int ChoreCell { get; init; }
+    public bool IsAttemptingOverride { get; init; }
 }


### PR DESCRIPTION
Search criteria was too strict and was always checking for chore position which wont match in case of dupe position desync.

TODO:
- FetchChore still missing on client side.
- If host re-assign chore client does not comply with it (even that receiving and executing chores) (race condition?).
- Retry might become redundant now.
- If host completes a chore earlier - it will send IdleChore to the client with an unfinished chore.

I'll either adress those TODO before clossing a ticket (more PR will be created) or create separate tickets.