### PR TITLE
#11 Remove retries since they do not fix any issues for now.

### DIFF
--- a/MultiplayerMod/Game/Chores/HostChores.cs
+++ b/MultiplayerMod/Game/Chores/HostChores.cs
@@ -4,6 +4,6 @@ namespace MultiplayerMod.Game.Chores;
 
 public static class HostChores {
 
-    public static Dictionary<int, Chore.Precondition.Context?> Index { get; } = new();
+    public static Dictionary<int, Queue<Chore.Precondition.Context>> Index { get; } = new();
 
 }

--- a/MultiplayerMod/Multiplayer/Patches/ChoreConsumerPatch.cs
+++ b/MultiplayerMod/Multiplayer/Patches/ChoreConsumerPatch.cs
@@ -13,10 +13,10 @@ public class ChoreConsumerPatch {
             return true;
 
         var instanceId = __instance.gameObject.GetComponent<KPrefabID>().InstanceID;
-        var choreContext = HostChores.Index.GetValueSafe(instanceId);
+        var queue = HostChores.Index.GetValueSafe(instanceId);
+        var choreContext = (queue?.Count ?? 0) > 0 ? queue?.Dequeue() : null;
         __result = choreContext != null;
         if (choreContext != null) out_context = choreContext.Value;
-        HostChores.Index.Remove(instanceId);
 
         return false;
     }


### PR DESCRIPTION
Replaced Dictionary type of chores to have a queue instead of single value. However I didn't see occasions of having more than 1 element in the queue.

TODO:

- FetchChore still missing on client side.
- If host re-assign chore client does not comply with it (even that receiving and executing chores).
  - New observation: dupe that must cancel chore - does not do chore, however run to the job site. Another dupe who must do chore does not move, but does chore upon first dupe arrival (from a distance).
- If host completes a chore earlier... - created ticket #56