### PR TITLE
#51 Fix client failures during host save/sync

### DIFF
--- a/MultiplayerMod/Core/Unity/GameObjectExtension.cs
+++ b/MultiplayerMod/Core/Unity/GameObjectExtension.cs
@@ -1,0 +1,10 @@
+﻿using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace MultiplayerMod.Core.Unity;
+
+public static class GameObjectExtension {
+    public static void DestroyOnLoad(this GameObject go) {
+        SceneManager.MoveGameObjectToScene(go, SceneManager.GetActiveScene());
+    }
+}

--- a/MultiplayerMod/Multiplayer/Commands/ShowOverlay.cs
+++ b/MultiplayerMod/Multiplayer/Commands/ShowOverlay.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace MultiplayerMod.Multiplayer.Commands;
+
+[Serializable]
+public class ShowOverlay : IMultiplayerCommand {
+    public void Execute() => LoadingOverlay.Load(() => { });
+}

--- a/MultiplayerMod/Multiplayer/Configuration/MultiplayerCoordinator.cs
+++ b/MultiplayerMod/Multiplayer/Configuration/MultiplayerCoordinator.cs
@@ -112,10 +112,12 @@ public class MultiplayerCoordinator {
                 break;
         }
 
-        UnityObject.CreateStaticWithComponent<
+        var go = UnityObject.CreateStaticWithComponent<
             DrawCursorComponent,
             WorldDebugSnapshotRunner
         >();
+        go.DestroyOnLoad();
+
         MultiplayerState.WorldSpawned = true;
     }
 

--- a/MultiplayerMod/Multiplayer/World/WorldManager.cs
+++ b/MultiplayerMod/Multiplayer/World/WorldManager.cs
@@ -3,6 +3,7 @@ using MultiplayerMod.Core.Dependency;
 using MultiplayerMod.Core.Patch;
 using MultiplayerMod.Multiplayer.Commands;
 using MultiplayerMod.Multiplayer.Commands.Speed;
+using MultiplayerMod.Multiplayer.State;
 using MultiplayerMod.Network;
 
 namespace MultiplayerMod.Multiplayer.World;
@@ -19,10 +20,14 @@ public static class WorldManager {
 
     public static void Sync() {
         server.Send(new PauseGame());
+        // TODO: Improvement: overlay should be shown on server as well. But it must be hidden as soon as all
+        // connected clients are ready.
+        server.Send(new ShowOverlay(), MultiplayerCommandOptions.SkipHost);
         server.Send(new LoadWorld(GetWorldSave()), MultiplayerCommandOptions.SkipHost);
     }
 
     public static void LoadWorldSave(byte[] data) {
+        MultiplayerState.WorldSpawned = false;
         var path = Path.GetTempFileName();
         using (var writer = new BinaryWriter(File.OpenWrite(path)))
             writer.Write(data);

--- a/MultiplayerMod/mod_info.yaml
+++ b/MultiplayerMod/mod_info.yaml
@@ -1,4 +1,4 @@
 supportedContent: VANILLA_ID
 minimumSupportedBuild: 537329
-version: 0.1.1-alpha
+version: 0.1.2-alpha
 APIVersion: 2


### PR DESCRIPTION
#51 Fix client failures during host save/sync. Show overlay while syn…c on clients only.

The issue was caused by handling cursor position messages while sync (world is loading). As a fix - reset worldSpawned state + make sure that DrawCursorComponent.cs does not exist while game is loading by making it limited to a single scene only (undo DoNotDestroyOnLoad).