### PR TITLE
#68 Fix autosave not enough space issue.

### DIFF
--- a/MultiplayerMod/Multiplayer/World/WorldManager.cs
+++ b/MultiplayerMod/Multiplayer/World/WorldManager.cs
@@ -13,7 +13,7 @@ public static class WorldManager {
     private static readonly IMultiplayerServer server = Container.Get<IMultiplayerServer>();
 
     public static byte[] GetWorldSave() {
-        var path = SaveLoader.GetActiveAutoSavePath();
+        var path = SaveLoader.GetActiveSaveFilePath();
         PatchControl.RunWithDisabledPatches(() => SaveLoader.Instance.Save(path));
         return File.ReadAllBytes(path);
     }

--- a/MultiplayerMod/mod_info.yaml
+++ b/MultiplayerMod/mod_info.yaml
@@ -1,4 +1,4 @@
 supportedContent: VANILLA_ID
 minimumSupportedBuild: 537329
-version: 0.1.2-alpha
+version: 0.1.3-alpha
 APIVersion: 2


### PR DESCRIPTION
Problem was with using AutoSave filename for saving instead of active file name. This was causing during default autosave logic since it is relying on the filename to contain special text pattern (`Cycle XX`), while autosave file does not have it. Fixed by asung current filename (which is in the right format).

Be aware that old save files seems to be affected, hence it is required to start a new game to have fix applied.