### PR TITLE
Fix error during hard sync.

### DIFF
--- a/MultiplayerMod/Core/Unity/UnityObject.cs
+++ b/MultiplayerMod/Core/Unity/UnityObject.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
@@ -6,7 +7,7 @@ namespace MultiplayerMod.Core.Unity;
 
 public abstract class UnityObject {
 
-    private static IntPtr NonZeroPtr = new(1);
+    private static IntPtr NonZeroPtr = Marshal.AllocHGlobal(1);
 
     public static GameObject CreateStaticWithComponent<T>() where T : Component =>
         CreateWithComponents(false, typeof(T));

--- a/MultiplayerMod/mod_info.yaml
+++ b/MultiplayerMod/mod_info.yaml
@@ -1,4 +1,4 @@
 supportedContent: VANILLA_ID
 minimumSupportedBuild: 537329
-version: 0.1.3-alpha
+version: 0.1.4-alpha
 APIVersion: 2


### PR DESCRIPTION
Error was caused by fake Unity objects created with m_CachedPtr == 1. Replace with allocated memory instead.