### PR TITLE
Multiplayer object identity

### DIFF
--- a/MultiplayerMod/Core/Unity/Dev/DevToolSceneInspectorPatch.cs
+++ b/MultiplayerMod/Core/Unity/Dev/DevToolSceneInspectorPatch.cs
@@ -1,0 +1,21 @@
+﻿using HarmonyLib;
+using ImGuiNET;
+
+namespace MultiplayerMod.Core.Unity.Dev;
+
+[HarmonyPatch(typeof(DevToolSceneInspector))]
+public class DevToolSceneInspectorPatch {
+
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(DevToolSceneInspector.DisplayField))]
+    private static bool DisplayFieldPrefix(ref bool __result, string name, System.Type ft, ref object obj) {
+        if (ft != typeof(long?))
+            return true;
+
+        var v = (long?) obj;
+        ImGui.LabelText(name, v.Value.ToString());
+        __result = true;
+        return false;
+    }
+
+}

--- a/MultiplayerMod/Directory.Build.targets
+++ b/MultiplayerMod/Directory.Build.targets
@@ -15,8 +15,8 @@
     <Target Name="ExposeAssemblies" DependsOnTargets="BuildAssemblyExposer" BeforeTargets="PreBuildEvent">
         <ItemGroup>
             <ExposeAssemblies Include="$(ManagedPath)\Assembly-CSharp*.dll"/>
-            <ExposureRules Include="Private targets to public">
-                <PatternRule>^private</PatternRule>
+            <ExposureRules Include="Private and internal targets to public">
+                <PatternRule>^(private|internal)</PatternRule>
                 <TargetRule>All</TargetRule>
                 <VisibilityRule>Public</VisibilityRule>
             </ExposureRules>

--- a/MultiplayerMod/Game/Chores/ChoreConsumerEvents.cs
+++ b/MultiplayerMod/Game/Chores/ChoreConsumerEvents.cs
@@ -11,7 +11,7 @@ public class ChoreConsumerEvents {
     public static event Action<FindNextChoreEventArgs> FindNextChore;
 
     public static void Postfix(ChoreConsumer __instance, Chore.Precondition.Context out_context, ref bool __result) {
-        if (MultiplayerState.Role != MultiplayerRole.Host)
+        if (MultiplayerGame.Role != MultiplayerRole.Host)
             return;
 
         if (!__result)

--- a/MultiplayerMod/Game/Extension/GameExtensionsConfigurator.cs
+++ b/MultiplayerMod/Game/Extension/GameExtensionsConfigurator.cs
@@ -1,0 +1,12 @@
+﻿using MultiplayerMod.Game.Objects;
+
+namespace MultiplayerMod.Game.Extension;
+
+public class GameExtensionsConfigurator {
+
+    public GameExtensionsConfigurator() {
+        KInstantiateEvents.Create += gameObject => gameObject.AddComponent<GameObjectExtension>();
+        KPrefabIdEvents.Deserialize += kPrefabId => kPrefabId.gameObject.AddComponent<GameObjectExtension>();
+    }
+
+}

--- a/MultiplayerMod/Game/Extension/GameObjectExtension.cs
+++ b/MultiplayerMod/Game/Extension/GameObjectExtension.cs
@@ -1,0 +1,7 @@
+﻿namespace MultiplayerMod.Game.Extension;
+
+public class GameObjectExtension : KMonoBehaviour {
+
+    public int GridLayer { get; set; }
+
+}

--- a/MultiplayerMod/Game/GameComponentLoader.cs
+++ b/MultiplayerMod/Game/GameComponentLoader.cs
@@ -1,0 +1,15 @@
+﻿using HarmonyLib;
+using MultiplayerMod.Core.Dependency;
+using MultiplayerMod.Core.Loader;
+using MultiplayerMod.Game.Extension;
+
+namespace MultiplayerMod.Game;
+
+// ReSharper disable once UnusedType.Global
+public class GameComponentLoader : IModComponentLoader {
+
+    public void OnLoad(Harmony harmony) {
+        Container.Register(new GameExtensionsConfigurator());
+    }
+
+}

--- a/MultiplayerMod/Game/KExtensions.cs
+++ b/MultiplayerMod/Game/KExtensions.cs
@@ -1,0 +1,10 @@
+﻿using UnityEngine;
+
+namespace MultiplayerMod.Game;
+
+public static class KExtensions {
+
+    public static int? GetKPrefabInstanceId(this GameObject gameObject) =>
+        gameObject.GetComponent<KPrefabID>()?.InstanceID;
+
+}

--- a/MultiplayerMod/Game/Location/GameObjectLocation.cs
+++ b/MultiplayerMod/Game/Location/GameObjectLocation.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using MultiplayerMod.Game.Extension;
+using UnityEngine;
+
+namespace MultiplayerMod.Game.Location;
+
+[Serializable]
+public class GameObjectLocation {
+
+    public int Cell { get; }
+    public int Layer { get; }
+
+    public GameObjectLocation(int cell, int layer) {
+        Cell = cell;
+        Layer = layer;
+    }
+
+    public GameObjectLocation(GameObject gameObject) {
+        Cell = Grid.PosToCell(gameObject);
+        Layer = GetLayer(gameObject);
+    }
+
+    private int GetLayer(GameObject gameObject) => gameObject.GetComponent<GameObjectExtension>()?.GridLayer ?? -1;
+
+    public GameObject GetGameObject() => Grid.Objects[Cell, Layer];
+
+    public override string ToString() => $"{Cell}:{Layer}";
+
+}

--- a/MultiplayerMod/Game/Location/GridObjectLayerIndexerPatch.cs
+++ b/MultiplayerMod/Game/Location/GridObjectLayerIndexerPatch.cs
@@ -1,0 +1,25 @@
+﻿using HarmonyLib;
+using MultiplayerMod.Game.Extension;
+using UnityEngine;
+
+namespace MultiplayerMod.Game.Location;
+
+// ReSharper disable once UnusedType.Global
+[HarmonyPatch(typeof(Grid.ObjectLayerIndexer))]
+public static class GridObjectLayerIndexerPatch {
+
+    // ReSharper disable once UnusedMember.Local
+    [HarmonyPostfix]
+    [HarmonyPatch("set_Item")]
+    private static void SetItemPostfix(int cell, int layer, GameObject value) {
+        if (value == null)
+            return;
+
+        var extension = value.GetComponent<GameObjectExtension>();
+        if (extension == null)
+            return;
+
+        extension.GridLayer = layer;
+    }
+
+}

--- a/MultiplayerMod/Game/Objects/KInstantiateEvents.cs
+++ b/MultiplayerMod/Game/Objects/KInstantiateEvents.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using HarmonyLib;
+using UnityEngine;
+
+namespace MultiplayerMod.Game.Objects;
+
+[HarmonyPatch(typeof(Util))]
+public static class KInstantiateEvents {
+
+    public static event Action<GameObject> Create;
+
+    // ReSharper disable once UnusedMember.Local
+    [HarmonyPostfix]
+    [HarmonyPatch(
+        nameof(Util.KInstantiate),
+        typeof(GameObject),
+        typeof(Vector3),
+        typeof(Quaternion),
+        typeof(GameObject),
+        typeof(string),
+        typeof(bool),
+        typeof(int)
+    )]
+    private static void InstantiatePostfix(GameObject __result, bool initialize_id) {
+        if (!initialize_id)
+            return;
+        var kPrefabId = __result.GetComponent<KPrefabID>();
+        if (kPrefabId == null)
+            return;
+        Create?.Invoke(__result);
+    }
+
+}

--- a/MultiplayerMod/Game/Objects/KPrefabIdEvents.cs
+++ b/MultiplayerMod/Game/Objects/KPrefabIdEvents.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using HarmonyLib;
+
+namespace MultiplayerMod.Game.Objects;
+
+[HarmonyPatch(typeof(KPrefabID))]
+public static class KPrefabIdEvents {
+
+    public static event Action<KPrefabID> Deserialize;
+
+    // ReSharper disable once UnusedMember.Local
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(KPrefabID.OnDeserializedMethod))]
+    private static void OnDeserializedPrefix(KPrefabID __instance) => Deserialize?.Invoke(__instance);
+
+}

--- a/MultiplayerMod/Multiplayer/Commands/State/SyncMultiplayerState.cs
+++ b/MultiplayerMod/Multiplayer/Commands/State/SyncMultiplayerState.cs
@@ -4,16 +4,16 @@ using MultiplayerMod.Multiplayer.State;
 namespace MultiplayerMod.Multiplayer.Commands.State;
 
 [Serializable]
-public class SyncSharedState : IMultiplayerCommand {
+public class SyncMultiplayerState : IMultiplayerCommand {
 
-    private MultiplayerSharedState state;
+    private MultiplayerState state;
 
-    public SyncSharedState(MultiplayerSharedState state) {
+    public SyncMultiplayerState(MultiplayerState state) {
         this.state = state;
     }
 
     public void Execute() {
-        MultiplayerState.Shared = state;
+        MultiplayerGame.State = state;
     }
 
 }

--- a/MultiplayerMod/Multiplayer/Commands/State/UpdateCursorPosition.cs
+++ b/MultiplayerMod/Multiplayer/Commands/State/UpdateCursorPosition.cs
@@ -16,7 +16,7 @@ public class UpdateCursorPosition : IMultiplayerCommand {
     }
 
     public void Execute() {
-        MultiplayerState.Shared.Players.TryGetValue(player, out var state);
+        MultiplayerGame.State.Players.TryGetValue(player, out var state);
         if (state == null)
             return;
 

--- a/MultiplayerMod/Multiplayer/Components/DrawCursorComponent.cs
+++ b/MultiplayerMod/Multiplayer/Components/DrawCursorComponent.cs
@@ -18,7 +18,7 @@ public class DrawCursorComponent : MonoBehaviour {
     }
 
     private void OnGUI() {
-        foreach (var (player, state) in MultiplayerState.Shared.Players) {
+        foreach (var (player, state) in MultiplayerGame.State.Players) {
             if (player.Equals(client.Player))
                 continue;
 

--- a/MultiplayerMod/Multiplayer/Configuration/MultiplayerCoordinator.cs
+++ b/MultiplayerMod/Multiplayer/Configuration/MultiplayerCoordinator.cs
@@ -57,7 +57,7 @@ public class MultiplayerCoordinator {
     }
 
     private void OnPlayerConnected(object sender, PlayerConnectedEventArgs e) {
-        MultiplayerState.Shared.Players[e.Player] = new PlayerSharedState(e.Player);
+        MultiplayerGame.State.Players[e.Player] = new PlayerState(e.Player);
         if (e.Player.Equals(client.Player))
             return;
 
@@ -77,8 +77,8 @@ public class MultiplayerCoordinator {
     private void OnClientStateChanged(object sender, ClientStateChangedEventArgs e) {
         switch (e.State) {
             case MultiplayerClientState.Connecting:
-                if (MultiplayerState.Role != MultiplayerRole.Host) {
-                    MultiplayerState.Role = MultiplayerRole.Client;
+                if (MultiplayerGame.Role != MultiplayerRole.Host) {
+                    MultiplayerGame.Role = MultiplayerRole.Client;
                     LoadingOverlay.Load(() => { });
                 }
                 break;
@@ -89,7 +89,7 @@ public class MultiplayerCoordinator {
     }
 
     private void ClientOnCommandReceived(object sender, CommandReceivedEventArgs e) {
-        if (!MultiplayerState.WorldSpawned && e.Command is not LoadWorld) {
+        if (!MultiplayerGame.WorldSpawned && e.Command is not LoadWorld) {
             log.Warning($"Command {e.Command.GetType().FullName} received, but the world isn't spawned yet");
             return;
         }
@@ -100,7 +100,7 @@ public class MultiplayerCoordinator {
     #endregion
 
     private void OnWorldSpawned() {
-        switch (MultiplayerState.Role) {
+        switch (MultiplayerGame.Role) {
             case MultiplayerRole.None:
                 return;
             case MultiplayerRole.Host:
@@ -119,11 +119,11 @@ public class MultiplayerCoordinator {
             WorldDebugSnapshotRunner
         >();
 
-        MultiplayerState.WorldSpawned = true;
+        MultiplayerGame.WorldSpawned = true;
     }
 
     private void OnWorldDestroy() {
-        switch (MultiplayerState.Role) {
+        switch (MultiplayerGame.Role) {
             case MultiplayerRole.Host:
                 if (client.State >= MultiplayerClientState.Connecting)
                     client.Disconnect();

--- a/MultiplayerMod/Multiplayer/Configuration/ServerEventBindings.cs
+++ b/MultiplayerMod/Multiplayer/Configuration/ServerEventBindings.cs
@@ -26,7 +26,7 @@ public class ServerEventBindings {
 
         MultiplayerEvents.PlayerWorldSpawned += player => server.Send(
             player,
-            new SyncSharedState(MultiplayerState.Shared)
+            new SyncMultiplayerState(MultiplayerGame.State)
         );
         WorldDebugSnapshotRunner.SnapshotAvailable += snapshot => server.Send(new SyncWorldDebugSnapshot(snapshot));
         SaveLoaderEvents.WorldSaved += WorldManager.Sync;

--- a/MultiplayerMod/Multiplayer/MultiplayerLoader.cs
+++ b/MultiplayerMod/Multiplayer/MultiplayerLoader.cs
@@ -2,14 +2,17 @@
 using MultiplayerMod.Core.Dependency;
 using MultiplayerMod.Core.Loader;
 using MultiplayerMod.Multiplayer.Configuration;
+using MultiplayerMod.Multiplayer.Objects;
 
 namespace MultiplayerMod.Multiplayer;
 
+// ReSharper disable once UnusedType.Global
 [ModComponentOrder(ModComponentOrder.Configuration)]
 public class MultiplayerLoader : IModComponentLoader {
 
     public void OnLoad(Harmony harmony) {
         Container.Register(new MultiplayerCoordinator());
+        Container.Register(new MultiplayerObjectsConfigurator());
     }
 
 }

--- a/MultiplayerMod/Multiplayer/Objects/MultiplayerIdentityProvider.cs
+++ b/MultiplayerMod/Multiplayer/Objects/MultiplayerIdentityProvider.cs
@@ -1,0 +1,15 @@
+﻿using MultiplayerMod.Game.World;
+
+namespace MultiplayerMod.Multiplayer.Objects;
+
+public static class MultiplayerIdentityProvider {
+
+    private static long nextId;
+
+    public static long GetNextId() => nextId++;
+
+    static MultiplayerIdentityProvider() {
+        WorldGenSpawnerEvents.Spawned += () => { nextId = KPrefabID.NextUniqueID; };
+    }
+
+}

--- a/MultiplayerMod/Multiplayer/Objects/MultiplayerInstance.cs
+++ b/MultiplayerMod/Multiplayer/Objects/MultiplayerInstance.cs
@@ -1,0 +1,14 @@
+﻿using MultiplayerMod.Multiplayer.State;
+
+namespace MultiplayerMod.Multiplayer.Objects;
+
+public class MultiplayerInstance : KMonoBehaviour {
+
+    public long? Id { get; set; }
+
+    protected override void OnCleanUp() {
+        if (Id != null)
+            MultiplayerGame.Objects.Remove(Id.Value);
+    }
+
+}

--- a/MultiplayerMod/Multiplayer/Objects/MultiplayerObjects.cs
+++ b/MultiplayerMod/Multiplayer/Objects/MultiplayerObjects.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace MultiplayerMod.Multiplayer.Objects;
+
+public class MultiplayerObjects {
+
+    private readonly Dictionary<long, GameObject> objects = new();
+
+    public void Add(MultiplayerInstance instance) {
+        instance.Id ??= MultiplayerIdentityProvider.GetNextId();
+        objects[instance.Id.Value] = instance.gameObject;
+    }
+
+    public void Remove(long objectId) => objects.Remove(objectId);
+
+    public GameObject this[long id] => objects[id];
+
+    public void Clear() => objects.Clear();
+
+}

--- a/MultiplayerMod/Multiplayer/Objects/MultiplayerObjectsConfigurator.cs
+++ b/MultiplayerMod/Multiplayer/Objects/MultiplayerObjectsConfigurator.cs
@@ -1,0 +1,17 @@
+﻿using MultiplayerMod.Game.Objects;
+using MultiplayerMod.Multiplayer.State;
+
+namespace MultiplayerMod.Multiplayer.Objects;
+
+public class MultiplayerObjectsConfigurator {
+
+    public MultiplayerObjectsConfigurator() {
+        KInstantiateEvents.Create += gameObject => MultiplayerGame.Objects.Add(gameObject.AddComponent<MultiplayerInstance>());
+        KPrefabIdEvents.Deserialize += kPrefabId => {
+            var data = kPrefabId.gameObject.AddComponent<MultiplayerInstance>();
+            MultiplayerGame.Objects.Add(data);
+            data.Id = kPrefabId.InstanceID;
+        };
+    }
+
+}

--- a/MultiplayerMod/Multiplayer/Patches/ChoreConsumerPatch.cs
+++ b/MultiplayerMod/Multiplayer/Patches/ChoreConsumerPatch.cs
@@ -9,7 +9,7 @@ public class ChoreConsumerPatch {
 
     // ReSharper disable once InconsistentNaming
     public static bool Prefix(ChoreConsumer __instance, ref Chore.Precondition.Context out_context, ref bool __result) {
-        if (MultiplayerState.Role != MultiplayerRole.Client)
+        if (MultiplayerGame.Role != MultiplayerRole.Client)
             return true;
 
         var instanceId = __instance.gameObject.GetComponent<KPrefabID>().InstanceID;

--- a/MultiplayerMod/Multiplayer/Patches/MainMenuPatch.cs
+++ b/MultiplayerMod/Multiplayer/Patches/MainMenuPatch.cs
@@ -12,7 +12,7 @@ internal class MainMenuPatch {
     [HarmonyPrefix]
     [HarmonyPatch("OnPrefabInit")]
     private static void OnPrefabInit(MainMenu __instance) {
-        MultiplayerState.Reset();
+        MultiplayerGame.Reset();
         var operations = Container.Get<IMultiplayerOperations>();
         __instance.AddButton("NEW MULTIPLAYER", highlight: true, CreateHostWrapper(__instance.NewGame));
         __instance.AddButton("LOAD MULTIPLAYER", highlight: false, CreateHostWrapper(__instance.LoadGame));
@@ -21,7 +21,7 @@ internal class MainMenuPatch {
 
     // TODO: Reset multiplayer role to none in case of button action cancellation
     private static System.Action CreateHostWrapper(System.Action action) => () => {
-        MultiplayerState.Role = MultiplayerRole.Host;
+        MultiplayerGame.Role = MultiplayerRole.Host;
         action();
     };
 

--- a/MultiplayerMod/Multiplayer/State/MultiplayerGame.cs
+++ b/MultiplayerMod/Multiplayer/State/MultiplayerGame.cs
@@ -1,0 +1,19 @@
+﻿using MultiplayerMod.Multiplayer.Objects;
+
+namespace MultiplayerMod.Multiplayer.State;
+
+public static class MultiplayerGame {
+
+    public static MultiplayerRole Role { get; set; }
+    public static bool WorldSpawned { get; set; }
+    public static MultiplayerState State { get; set; } = new();
+    public static MultiplayerObjects Objects { get; } = new();
+
+    public static void Reset() {
+        Role = MultiplayerRole.None;
+        WorldSpawned = false;
+        State = new MultiplayerState();
+        Objects.Clear();
+    }
+
+}

--- a/MultiplayerMod/Multiplayer/State/MultiplayerSharedState.cs
+++ b/MultiplayerMod/Multiplayer/State/MultiplayerSharedState.cs
@@ -1,9 +1,0 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace MultiplayerMod.Multiplayer.State;
-
-[Serializable]
-public class MultiplayerSharedState {
-    public Dictionary<IPlayer, PlayerSharedState> Players = new();
-}

--- a/MultiplayerMod/Multiplayer/State/MultiplayerState.cs
+++ b/MultiplayerMod/Multiplayer/State/MultiplayerState.cs
@@ -1,28 +1,9 @@
-﻿using MultiplayerMod.Core.Logging;
+﻿using System;
+using System.Collections.Generic;
 
 namespace MultiplayerMod.Multiplayer.State;
 
-public static class MultiplayerState {
-
-    private static readonly Core.Logging.Logger log = LoggerFactory.GetLogger(typeof(MultiplayerState));
-
-    private static MultiplayerRole role = MultiplayerRole.None;
-
-    public static MultiplayerRole Role {
-        get => role;
-        set {
-            role = value;
-            log.Trace(() => $"Setting role to {role}");
-        }
-    }
-
-    public static bool WorldSpawned { get; set; }
-
-    public static MultiplayerSharedState Shared { get; set; } = new();
-
-    public static void Reset() {
-        Role = MultiplayerRole.None;
-        WorldSpawned = false;
-    }
-
+[Serializable]
+public class MultiplayerState {
+    public Dictionary<IPlayer, PlayerState> Players = new();
 }

--- a/MultiplayerMod/Multiplayer/State/PlayerState.cs
+++ b/MultiplayerMod/Multiplayer/State/PlayerState.cs
@@ -4,11 +4,11 @@ using UnityEngine;
 namespace MultiplayerMod.Multiplayer.State;
 
 [Serializable]
-public class PlayerSharedState {
+public class PlayerState {
     public IPlayer Player { get; }
     public Vector2 CursorPosition { get; set; }
 
-    public PlayerSharedState(IPlayer player) {
+    public PlayerState(IPlayer player) {
         Player = player;
     }
 }

--- a/MultiplayerMod/Multiplayer/UI/Diagnostics/ColonyDiagnosticScreenPatch.cs
+++ b/MultiplayerMod/Multiplayer/UI/Diagnostics/ColonyDiagnosticScreenPatch.cs
@@ -9,7 +9,7 @@ public class ColonyDiagnosticScreenPatch {
     [HarmonyPrefix]
     [HarmonyPatch(nameof(ColonyDiagnosticScreen.SpawnTrackerLines))]
     public static void SpawnTrackerLines(ColonyDiagnosticScreen __instance, int world) {
-        if (MultiplayerState.Role == MultiplayerRole.None)
+        if (MultiplayerGame.Role == MultiplayerRole.None)
             return;
 
         __instance.AddDiagnostic<MultiplayerColonyDiagnostic>(

--- a/MultiplayerMod/Multiplayer/UI/Diagnostics/ColonyDiagnosticUtilityPatch.cs
+++ b/MultiplayerMod/Multiplayer/UI/Diagnostics/ColonyDiagnosticUtilityPatch.cs
@@ -10,7 +10,7 @@ static class ColonyDiagnosticUtilityPatch {
     [HarmonyPostfix]
     [HarmonyPatch(nameof(ColonyDiagnosticUtility.AddWorld))]
     private static void AddWorldPostfix(ColonyDiagnosticUtility __instance, int worldID) {
-        if (MultiplayerState.Role == MultiplayerRole.None)
+        if (MultiplayerGame.Role == MultiplayerRole.None)
             return;
 
         var colonyDiagnostic = new MultiplayerColonyDiagnostic(worldID);

--- a/MultiplayerMod/Multiplayer/World/WorldManager.cs
+++ b/MultiplayerMod/Multiplayer/World/WorldManager.cs
@@ -27,7 +27,7 @@ public static class WorldManager {
     }
 
     public static void LoadWorldSave(byte[] data) {
-        MultiplayerState.WorldSpawned = false;
+        MultiplayerGame.WorldSpawned = false;
         var path = Path.GetTempFileName();
         using (var writer = new BinaryWriter(File.OpenWrite(path)))
             writer.Write(data);

--- a/MultiplayerMod/MultiplayerMod.csproj
+++ b/MultiplayerMod/MultiplayerMod.csproj
@@ -27,5 +27,6 @@
         <Reference Include="UnityEngine.CoreModule" HintPath="$(ManagedPath)\UnityEngine.CoreModule.dll" Private="false" />
         <Reference Include="UnityEngine.ImageConversionModule" HintPath="$(ManagedPath)\UnityEngine.ImageConversionModule.dll" Private="false" />
         <Reference Include="UnityEngine.IMGUIModule" HintPath="$(ManagedPath)\UnityEngine.IMGUIModule.dll" Private="false" />
+        <Reference Include="ImGui.NET" HintPath="$(ManagedPath)\ImGui.NET.dll" Private="false" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Now we have two options for identifying game objects by its:
- location (cell + layer)
- multiplayer id (sequential number + player)

`KPrefabID.InstanceId` is considered extremely unreliable in multiplayer environment.

Now each game object instantiated via `Util.KInstantiate` will have `GameObjectExtension` that will be used for storing additional data required for the mod and `MultiplayerInstance` for multiplayer related data such as multiplayer id.

Initially all multiplayer ids are just equals to `KPrefabID.InstanceId`.